### PR TITLE
Fixed the haa-hfe and upperleg lengths

### DIFF
--- a/urdfs/common.xacro
+++ b/urdfs/common.xacro
@@ -7,9 +7,9 @@
 	<!-- standard distances -->
 	<property name="d_lr" value="0.414"/>
 	<property name="d_fh" value="0.747"/>
-	<property name="hipassembly_length" value="0.1075"/>
-	<property name="upperleg_length" value="0.364"/>
-    <property name="lowerleg_length" value="0.38009"/>
+	<property name="hipassembly_length" value="0.117"/>
+	<property name="upperleg_length" value="0.360"/>
+    <property name="lowerleg_length" value="0.380"/>
 
 	<!-- Knee offset angel in degree -->
 	<property name="knee_offset_angle" value="10."/>

--- a/urdfs/leg/leg.urdf.xacro
+++ b/urdfs/leg/leg.urdf.xacro
@@ -67,13 +67,13 @@
 						 ixy="${ixy_hipassembly}" ixz="${ixz_hipassembly}" iyz="${iyz_hipassembly}"/>
 			</inertial>
 			<visual>
-				<origin xyz="0 -0.046 0" rpy="0 ${-PI/2} ${-PI/2}"/><!-- TODO: -0.044 ask Jake -->
+				<origin xyz="0 -0.046 0" rpy="0 ${-PI/2} ${-PI/2}"/>
 				<geometry>
 					<mesh filename="package://hyq2max_description/meshes/leg/hipassembly.dae" scale="1 1 1"/>
 				</geometry>
 			</visual>
 			<collision>
-				<origin xyz="0 -0.046 0" rpy="0 ${-PI/2} ${-PI/2}"/><!-- TODO: -0.044 ask Jake -->
+				<origin xyz="0 -0.046 0" rpy="0 ${-PI/2} ${-PI/2}"/>
 				<geometry>
 					<mesh filename="package://hyq2max_description/meshes/leg/hipassembly.dae" scale="1 1 1"/>
 				</geometry>
@@ -88,13 +88,13 @@
 						 ixy="${reflect_front*ixy_upperleg}" ixz="${reflect_left*ixz_upperleg}" iyz="${reflect_left*reflect_front*iyz_upperleg}"/>
 			</inertial>
 			<visual> 
-				<origin xyz="0 0 ${-0.03*reflect_left}" rpy="${(1-reflect_left)*PI/2} 0 0"/> <!-- TODO Ask displacement Jake -->
+				<origin xyz="0 0 ${-0.03*reflect_left}" rpy="${(1-reflect_left)*PI/2} 0 0"/>
 				<geometry>
 					<mesh filename="package://hyq2max_description/meshes/leg/upperleg.dae" scale="1 1 1"/>
 				</geometry>
 			</visual>
 			<collision>
-				<origin xyz="0 0 ${-0.03*reflect_left}" rpy="${(1-reflect_left)*PI/2} 0 0"/> <!-- TODO Ask displacement Jake -->
+				<origin xyz="0 0 ${-0.03*reflect_left}" rpy="${(1-reflect_left)*PI/2} 0 0"/>
 				<geometry>
 					<mesh filename="package://hyq2max_description/meshes/leg/upperleg.dae" scale="1 1 1"/>
 				</geometry>


### PR DESCRIPTION
This pull request fix an important bug in the hyq2max model. The haa-hfe and upperleg lengths are changed according to the latest CAD information. Alex, MarcoF, Bilal and I checked these values. These are the new values
- haa-hfe length: 107.75 -> 117 mm
- upperleg length: 364 -> 360 mm

**Note**
This pull request doesn't affect the RobCoGen model that is used in some controllers. MarcoF will update this information, and later, I will propagate to dls repo.
